### PR TITLE
Fixed the copy endpoint so it actually copies (my bad lol)

### DIFF
--- a/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -12,6 +12,14 @@ public static class ActivityEndpoints
     {
         var group = app.MapGroup("weekplan");
         
+        // GET all activities (mainly for debugging)
+        group.MapGet("/", async (GirafDbContext dbContext) =>
+            await dbContext.Activities
+                .Select(a => a.ToDTO())
+                .AsNoTracking()
+                .ToListAsync()
+        );
+        
         // GET activities for one day for citizen
         group.MapGet("/{citizenId}", async (int citizenId, string date, GirafDbContext dbContext) =>
             await dbContext.Activities
@@ -41,6 +49,41 @@ public static class ActivityEndpoints
             return Results.Created($"/activity/{activity.Id}", activity.ToDTO());
         });
         
+        // POST copy activity
+        group.MapPost("/activity/copy", async (int citizenId, string dateStr, string newDateStr, GirafDbContext dbContext) => 
+        {
+            var date = DateOnly.Parse(dateStr);
+            var newDate = DateOnly.Parse(newDateStr);
+
+            var result = await dbContext.Activities
+                .Where(a => a.CitizenId == citizenId)
+                .Where(a => a.Date == date)
+                .AsNoTracking()
+                .ToListAsync();
+            
+            if(result is null)
+            {
+                return Results.NotFound();
+            }
+
+            foreach(Activity activity in result) 
+            {
+                dbContext.Activities.Add(new Activity
+                {
+                    CitizenId = citizenId,
+                    Date = newDate,
+                    Name = activity.Name,
+                    Description = activity.Description,
+                    StartTime = activity.StartTime,
+                    EndTime = activity.EndTime
+                });
+            }
+            
+            await dbContext.SaveChangesAsync();
+
+            return Results.Ok();
+        });
+        
         // PUT updated activity
         group.MapPut("/activity/{id}", async (int id, UpdateActivityDTO updatedActivity, GirafDbContext dbContext) =>
         {
@@ -56,32 +99,6 @@ public static class ActivityEndpoints
             
             return Results.Ok();
         });
-        
-        // PUT copy activity
-        group.MapPut("/activity/move", async (int citizenId, string dateStr, string newDateStr, GirafDbContext dbContext) => 
-        {
-            var date = DateOnly.Parse(dateStr);
-            var newDate = DateOnly.Parse(newDateStr);
-
-            var result = await dbContext.Activities
-                            .Where(a => a.CitizenId == citizenId)
-                            .Where(a => a.Date == date)
-                            .ToListAsync();
-            
-            if(result is null)
-            {
-                return Results.NotFound();
-            }
-
-            foreach(Activity activity in result) 
-            {
-                activity.Date = newDate;
-            }
-            
-            await dbContext.SaveChangesAsync();
-
-            return Results.Ok();
-        }); 
 
         // DELETE activity
         group.MapDelete("/activity/{id}", async (int id, GirafDbContext dbContext) =>


### PR DESCRIPTION
# Description

We realized the other endpoint moved the activities instead of copying them as requested, so we fixed it.