### PR TITLE
Copy activity endpoint now takes an array of IDs of activities to copy

### DIFF
--- a/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -50,7 +50,7 @@ public static class ActivityEndpoints
         });
         
         // POST copy activity
-        group.MapPost("/activity/copy", async (int citizenId, string dateStr, string newDateStr, GirafDbContext dbContext) => 
+        group.MapPost("/activity/copy", async (int citizenId, List<int> ids, string dateStr, string newDateStr, GirafDbContext dbContext) => 
         {
             var date = DateOnly.Parse(dateStr);
             var newDate = DateOnly.Parse(newDateStr);
@@ -58,6 +58,7 @@ public static class ActivityEndpoints
             var result = await dbContext.Activities
                 .Where(a => a.CitizenId == citizenId)
                 .Where(a => a.Date == date)
+                .Where(a => ids.Contains(a.Id))
                 .AsNoTracking()
                 .ToListAsync();
             


### PR DESCRIPTION
# Description

Copy activity endpoint now takes an array of IDs of activities to copy.
