### PR TITLE
Remove admin auth

### DIFF
--- a/GirafAPI/Endpoints/UserEndpoints.cs
+++ b/GirafAPI/Endpoints/UserEndpoints.cs
@@ -17,14 +17,13 @@ public static class UsersEndpoints
     public static RouteGroupBuilder MapUsersEndpoints(this WebApplication app)
     {
         //TODO Add authorization requirement to this group for users and admins
-        var group = app.MapGroup("users").RequireAuthorization("AdminPolicy");
+        var group = app.MapGroup("users");
 
         // POST /users
         group.MapPost("/", async (CreateUserDTO newUser, UserManager<GirafUser> userManager) =>
         {
             GirafUser user = newUser.ToEntity();
             var result = await userManager.CreateAsync(user, newUser.Password);
-            
             return result.Succeeded ? Results.Created($"/users/{user.Id}", user.ToDTO()) : Results.BadRequest();
         })
         .WithName("CreateUser")

--- a/GirafAPI/Entities/Users/DTOs/CreateUserDTO.cs
+++ b/GirafAPI/Entities/Users/DTOs/CreateUserDTO.cs
@@ -18,4 +18,7 @@ public record CreateUserDTO
     
     [StringLength(50)]
     public required string LastName { get; set; }
+    
+    [StringLength(100)]
+    public string? UserName { get; set; } 
 }

--- a/GirafAPI/Entities/Users/DTOs/CreateUserDTO.cs
+++ b/GirafAPI/Entities/Users/DTOs/CreateUserDTO.cs
@@ -19,6 +19,4 @@ public record CreateUserDTO
     [StringLength(50)]
     public required string LastName { get; set; }
     
-    [StringLength(100)]
-    public string? UserName { get; set; } 
 }

--- a/GirafAPI/Mapping/UserMapping.cs
+++ b/GirafAPI/Mapping/UserMapping.cs
@@ -17,7 +17,7 @@ public static class UserMapping
             
             LastName = userDTO.LastName,
             
-            UserName = userDTO.FirstName + userDTO.LastName,
+            UserName = userDTO.Email,  
 
         };
     }

--- a/GirafAPI/Mapping/UserMapping.cs
+++ b/GirafAPI/Mapping/UserMapping.cs
@@ -16,6 +16,8 @@ public static class UserMapping
             FirstName = userDTO.FirstName,
             
             LastName = userDTO.LastName,
+            
+            UserName = userDTO.FirstName + userDTO.LastName,
 
         };
     }


### PR DESCRIPTION
# Description

Remove admin authorization and making sure that UserName is created on the backend as a user can not be registered unless they have a UserName. The reason this is done is because there is no other way of registering a user into the database, as Microsoft identity requires that there is a username instance.

## Type of change
*Delete unchecked boxes (only for Type of change)*

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It has been tested with the frontend that it registers and then you can login afterwards as it adds an entry to the database

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have Acceptance Tested this on an iOS device
- [x] I have Acceptance Tested this on an Android device
