### PR TITLE
Fixed claims not being updated by just using the token for the userId

### DIFF
--- a/GirafAPI/Authorization/OrgAdminRequirement.cs
+++ b/GirafAPI/Authorization/OrgAdminRequirement.cs
@@ -1,4 +1,8 @@
+using System.Security.Claims;
+using GirafAPI.Data;
+using GirafAPI.Entities.Users;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 
 namespace GirafAPI.Authorization;
 
@@ -7,18 +11,25 @@ public class OrgAdminRequirement : IAuthorizationRequirement;
 public class OrgAdminAuthorizationHandler : AuthorizationHandler<OrgAdminRequirement>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly UserManager<GirafUser> _userManager;
 
-    public OrgAdminAuthorizationHandler(IHttpContextAccessor httpContextAccessor)
+    public OrgAdminAuthorizationHandler(IHttpContextAccessor httpContextAccessor, UserManager<GirafUser> userManager)
     {
         _httpContextAccessor = httpContextAccessor;
+        _userManager = userManager;
     }
 
     protected override Task HandleRequirementAsync(
         AuthorizationHandlerContext context,
         OrgAdminRequirement requirement)
     {
-        var claims = context.User;
-        var orgIds = claims.Claims
+        var userId = _userManager.GetUserId(_httpContextAccessor.HttpContext.User);
+        var user = _userManager.FindByIdAsync(userId).GetAwaiter().GetResult();
+        
+        
+        var claims = _userManager.GetClaimsAsync(user).GetAwaiter().GetResult();
+        
+        var orgIds = claims
             .Where(c => c.Type == "OrgAdmin")
             .Select(c => c.Value)
             .ToList();

--- a/GirafAPI/Authorization/OrgMemberRequirement.cs
+++ b/GirafAPI/Authorization/OrgMemberRequirement.cs
@@ -1,4 +1,6 @@
+using GirafAPI.Entities.Users;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 
 namespace GirafAPI.Authorization;
 
@@ -7,21 +9,29 @@ public class OrgMemberRequirement : IAuthorizationRequirement;
 public class OrgMemberAuthorizationHandler : AuthorizationHandler<OrgMemberRequirement>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly UserManager<GirafUser> _userManager;
 
-    public OrgMemberAuthorizationHandler(IHttpContextAccessor httpContextAccessor)
+    public OrgMemberAuthorizationHandler(IHttpContextAccessor httpContextAccessor, UserManager<GirafUser> userManager)
     {
         _httpContextAccessor = httpContextAccessor;
+        _userManager = userManager;
     }
 
     protected override Task HandleRequirementAsync(
         AuthorizationHandlerContext context,
         OrgMemberRequirement requirement)
     {
-        var claims = context.User;
-        var orgIds = claims.Claims
-                                .Where(c => c.Type == "OrgMember")
-                                .Select(c => c.Value)
-                                .ToList();
+        
+        var userId = _userManager.GetUserId(_httpContextAccessor.HttpContext.User);
+        var user = _userManager.FindByIdAsync(userId).GetAwaiter().GetResult();
+        
+        
+        var claims = _userManager.GetClaimsAsync(user).GetAwaiter().GetResult();
+        
+        var orgIds = claims
+            .Where(c => c.Type == "OrgMember")
+            .Select(c => c.Value)
+            .ToList();
         
         var httpContext = _httpContextAccessor.HttpContext;
         var orgIdInUrl = httpContext.Request.RouteValues["orgId"];

--- a/GirafAPI/Endpoints/LoginEndpoints.cs
+++ b/GirafAPI/Endpoints/LoginEndpoints.cs
@@ -36,9 +36,6 @@ namespace GirafAPI.Endpoints
                     new Claim(ClaimTypes.Name, user.UserName)
                 };
 
-                var userClaims = await userManager.GetClaimsAsync(user);
-                claims.AddRange(userClaims);
-
                 var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.Value.SecretKey));
                 var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 

--- a/GirafAPI/Endpoints/OrganizationEndpoints.cs
+++ b/GirafAPI/Endpoints/OrganizationEndpoints.cs
@@ -89,12 +89,6 @@ public static class OrganizationEndpoints
                 {
                     try
                     {
-                        var userClaims = httpContext.User.Claims;
-                        foreach (var claim in userClaims)
-                        {
-                            Console.WriteLine($"{claim.Type}: {claim.Value}");
-                        }
-                        
                         var userId = userManager.GetUserId(httpContext.User);
                         
                         var user = userManager.FindByIdAsync(userId).GetAwaiter().GetResult();
@@ -174,6 +168,7 @@ public static class OrganizationEndpoints
                     return Results.Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
                 }
             })
+            .RequireAuthorization("OrganizationAdmin")
             .WithName("DeleteOrganization")
             .WithDescription("Deletes the organization.")
             .WithTags("Organizations")

--- a/GirafAPI/Extensions/ServiceExtensions.cs
+++ b/GirafAPI/Extensions/ServiceExtensions.cs
@@ -81,8 +81,8 @@ namespace GirafAPI.Extensions
 
         public static IServiceCollection ConfigureAuthorizationPolicies(this IServiceCollection services)
         {
-            services.AddSingleton<IAuthorizationHandler, OrgMemberAuthorizationHandler>();
-            services.AddSingleton<IAuthorizationHandler, OrgAdminAuthorizationHandler>();
+            services.AddScoped<IAuthorizationHandler, OrgMemberAuthorizationHandler>();
+            services.AddScoped<IAuthorizationHandler, OrgAdminAuthorizationHandler>();
             
             services.AddAuthorization(options =>
             {


### PR DESCRIPTION
## Description
- The token is now just used to get the userId, which is then used to get the user's claims via the userManager. This should fix the bug with tokens not being refreshed whenever a user joins an organization for example.

- Removed claim consolelog from testing
- Changed auth policies from singletons to Scoped

## Related issues
Tokens not refreshing their claims when a user joins an organization for example

## Checklist
- [x] My code is in the right place.\
- [x] My code fully addresses the issue I was working on.
- [x] My code follows the style guidelines.
- [x] I have added relevant comments explaining the purpose and function of my code (if necessary).
- [x] I have created a pull request and notified the teams.
