### PR TITLE
Added basic authorization to activity endpoints

### DIFF
--- a/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -34,6 +34,7 @@ public static class ActivityEndpoints
         .WithName("GetAllActivities")
         .WithDescription("Gets all activities.")
         .WithTags("Activities")
+        .RequireAuthorization()
         .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status500InternalServerError);
 
@@ -77,6 +78,7 @@ public static class ActivityEndpoints
         .WithName("GetActivitiesForCitizenOnDate")
         .WithDescription("Gets activities for a specific citizen on a given date.")
         .WithTags("Activities")
+        .RequireAuthorization()
         .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound)
         .Produces(StatusCodes.Status500InternalServerError);
@@ -125,6 +127,7 @@ public static class ActivityEndpoints
             .WithName("GetActivitiesForGradeOnDate")
             .WithDescription("Gets activities for a specific grade on a given date.")
             .WithTags("Activities")
+            .RequireAuthorization()
             .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
@@ -149,6 +152,7 @@ public static class ActivityEndpoints
         .WithName("GetActivityById")
         .WithDescription("Gets a specific activity by ID.")
         .WithTags("Activities")
+        .RequireAuthorization()
         .Produces<ActivityDTO>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound)
         .Produces(StatusCodes.Status500InternalServerError);
@@ -195,6 +199,7 @@ public static class ActivityEndpoints
         .WithName("CreateActivityForCitizen")
         .WithDescription("Creates a new activity for a citizen.")
         .WithTags("Activities")
+        .RequireAuthorization()
         .Accepts<CreateActivityDTO>("application/json")
         .Produces<ActivityDTO>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status404NotFound)
@@ -241,6 +246,7 @@ public static class ActivityEndpoints
             .WithName("CreateActivityForGrade")
             .WithDescription("Creates a new activity for a grade.")
             .WithTags("Activities")
+            .RequireAuthorization()
             .Accepts<CreateActivityDTO>("application/json")
             .Produces<ActivityDTO>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status404NotFound)
@@ -294,7 +300,8 @@ public static class ActivityEndpoints
                 //unexpected errors
                 return Results.Problem("An error occurred while copying the activities.", statusCode: StatusCodes.Status500InternalServerError);
             }
-        });
+        })
+        .RequireAuthorization();
 
         
         // PUT updated activity
@@ -337,6 +344,7 @@ public static class ActivityEndpoints
             .WithName("UpdateActivity")
             .WithDescription("Updates an existing activity using ID.")
             .WithTags("Activities")
+            .RequireAuthorization()
             .Accepts<UpdateActivityDTO>("application/json")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
@@ -371,7 +379,8 @@ public static class ActivityEndpoints
                 // unexpected errors
                 return Results.Problem("An error occurred while updating the activity status.", statusCode: StatusCodes.Status500InternalServerError);
             }
-        });
+        })
+        .RequireAuthorization();
 
 
         // DELETE activity
@@ -402,6 +411,7 @@ public static class ActivityEndpoints
         .WithName("DeleteActivity")
         .WithDescription("Deletes an activity by ID.")
         .WithTags("Activities")
+        .RequireAuthorization()
         .Produces(StatusCodes.Status204NoContent)
         .Produces(StatusCodes.Status404NotFound)
         .Produces(StatusCodes.Status400BadRequest)
@@ -441,6 +451,7 @@ public static class ActivityEndpoints
             .WithName("AssignPictogram")
             .WithDescription("Assigns a pictogram by ID.")
             .WithTags("Activities")
+            .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);


### PR DESCRIPTION
## Description
Activity endpoints were never updated to contain any kind of information about organizations, so it is not possible to add proper authorization using our current auth policies. I have added minimal auth to ensure that accessing activities at least requires a valid token.

## Checklist
- [x] My code is in the right place.\
- [x] My code fully addresses the issue I was working on.\
- [x] I have added appropriate tests and error handling.\
- [x] My code follows the style guidelines.\
- [x] I have added relevant comments explaining the purpose and function of my code (if necessary).\
- [x] I have added relevant documentation to the GitHub wiki.\
- [x] I have created a pull request and notified the teams.
