### PR TITLE
Basic auth for citizen endpoint and updated tests

### DIFF
--- a/Giraf.IntegrationTests/Endpoints/CitizenEndpointTests.cs
+++ b/Giraf.IntegrationTests/Endpoints/CitizenEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Giraf.IntegrationTests.Utils;
 using Giraf.IntegrationTests.Utils.DbSeeders;
@@ -14,7 +15,7 @@ using Xunit;
 namespace Giraf.IntegrationTests.Endpoints
 {
     [Collection("IntegrationTests")]
-    public class CitizensEndpointTests
+    public class CitizenEndpointTests
     {
         #region Get All Citizens Tests
 
@@ -175,6 +176,12 @@ namespace Giraf.IntegrationTests.Endpoints
                 var organization = await dbContext.Organizations.FirstOrDefaultAsync();
                 Assert.NotNull(organization);
                 var organizationId = organization.Id;
+                
+                TestAuthHandler.TestClaims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "testUserId"),
+                    new Claim("OrgAdmin", organizationId.ToString())
+                };
 
                 var createCitizenDto = new CreateCitizenDTO("New", "Citizen");
 
@@ -202,6 +209,12 @@ namespace Giraf.IntegrationTests.Endpoints
             // Arrange
             var factory = new GirafWebApplicationFactory(_ => new EmptyDb());
             var client = factory.CreateClient();
+            
+            TestAuthHandler.TestClaims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, "testUserId"),
+                new Claim("OrgAdmin", "badOrgId")
+            };
 
             var createCitizenDto = new CreateCitizenDTO("New", "Citizen");
 
@@ -231,6 +244,12 @@ namespace Giraf.IntegrationTests.Endpoints
                 var organization = await dbContext.Organizations.FirstOrDefaultAsync();
                 Assert.NotNull(organization);
                 var organizationId = organization.Id;
+                
+                TestAuthHandler.TestClaims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "testUserId"),
+                    new Claim("OrgAdmin", organizationId.ToString())
+                };
 
                 var citizen = await dbContext.Citizens.FirstOrDefaultAsync();
                 Assert.NotNull(citizen);
@@ -266,6 +285,12 @@ namespace Giraf.IntegrationTests.Endpoints
                 var organization = await dbContext.Organizations.FirstOrDefaultAsync();
                 Assert.NotNull(organization);
                 var organizationId = organization.Id;
+                
+                TestAuthHandler.TestClaims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "testUserId"),
+                    new Claim("OrgAdmin", organizationId.ToString())
+                };
 
                 // Act
                 var response = await client.DeleteAsync($"/citizens/{organizationId}/remove-citizen/999");
@@ -297,6 +322,12 @@ namespace Giraf.IntegrationTests.Endpoints
                 var citizenNotInOrg = await dbContext.Citizens.FirstOrDefaultAsync(c => c.Organization.Id == organization2.Id);
                 Assert.NotNull(citizenNotInOrg);
                 var citizenId = citizenNotInOrg.Id;
+                
+                TestAuthHandler.TestClaims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.NameIdentifier, "testUserId"),
+                    new Claim("OrgAdmin", organization1.Id.ToString())
+                };
 
                 // Act
                 var response = await client.DeleteAsync($"/citizens/{organization1.Id}/remove-citizen/{citizenId}");


### PR DESCRIPTION
## Description
Added basic auth for citizen endpoint and updated tests. Some endpoints could not be properly protected with current policies, as the requests themselves don't contain information about which organization is being accessed. Here, minimal authorization was added to ensure the user at least has a valid token.

## Related issues
#113 

## Checklist
- [x] My code is in the right place.\
- [x] My code fully addresses the issue I was working on.\
- [x] I have added appropriate tests and error handling.\
- [x] My code follows the style guidelines.\
- [x] I have added relevant comments explaining the purpose and function of my code (if necessary).\
- [x] I have added relevant documentation to the GitHub wiki.\
- [x] I have created a pull request and notified the teams.
