### PR TITLE
Revert previous changes to activityDTO

### DIFF
--- a/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -225,9 +225,9 @@ namespace Giraf.IntegrationTests.Endpoints
 
             var newActivityDto = new CreateActivityDTO
             (
-                Date: DateOnly.FromDateTime(DateTime.UtcNow),
-                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
-                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Date: DateOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)).ToString(),
                 PictogramId: pictogramId // Provide the valid PictogramId
             );
 
@@ -252,9 +252,9 @@ namespace Giraf.IntegrationTests.Endpoints
 
             var newActivityDto = new CreateActivityDTO
             (
-                Date: DateOnly.FromDateTime(DateTime.UtcNow),
-                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
-                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Date: DateOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)).ToString(),
                 PictogramId: null
             );
 
@@ -305,9 +305,9 @@ namespace Giraf.IntegrationTests.Endpoints
 
             var newActivityDto = new CreateActivityDTO
             (
-                Date: DateOnly.FromDateTime(DateTime.UtcNow),
-                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
-                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Date: DateOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)).ToString(),
                 PictogramId: pictogramId // Provide the valid PictogramId
             );
 
@@ -332,9 +332,9 @@ namespace Giraf.IntegrationTests.Endpoints
 
             var newActivityDto = new CreateActivityDTO
             (
-                Date: DateOnly.FromDateTime(DateTime.UtcNow),
-                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
-                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Date: DateOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)).ToString(),
                 PictogramId: null
             );
 
@@ -367,9 +367,9 @@ namespace Giraf.IntegrationTests.Endpoints
             
             var updateActivityDto = new UpdateActivityDTO
             (
-                Date: DateOnly.FromDateTime(DateTime.UtcNow),
-                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
-                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Date: DateOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)).ToString(),
                 IsCompleted: true,
                 PictogramId: 1,
                 CitizenId: 1
@@ -401,9 +401,9 @@ namespace Giraf.IntegrationTests.Endpoints
 
             var newActivityDto = new CreateActivityDTO
             (
-                Date: DateOnly.FromDateTime(DateTime.UtcNow),
-                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
-                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Date: DateOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                StartTime: TimeOnly.FromDateTime(DateTime.UtcNow).ToString(),
+                EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)).ToString(),
                 PictogramId: null
             );
 

--- a/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
+++ b/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
@@ -4,8 +4,8 @@ namespace GirafAPI.Entities.Activities.DTOs;
 
 public record CreateActivityDTO
 (
-    [Required]DateOnly Date,
-    [Required]TimeOnly StartTime,
-    [Required]TimeOnly EndTime,
+    [Required][StringLength(10)] string Date,
+    [Required][StringLength(10)] string StartTime,
+    [Required][StringLength(10)] string EndTime,
     int? PictogramId
 );

--- a/GirafAPI/Entities/Activities/DTOs/UpdateActivityDTO.cs
+++ b/GirafAPI/Entities/Activities/DTOs/UpdateActivityDTO.cs
@@ -5,9 +5,9 @@ namespace GirafAPI.Entities.Activities.DTOs;
 public record UpdateActivityDTO
 (
     [Required] int CitizenId,
-    [Required]DateOnly Date,
-    [Required]TimeOnly StartTime,
-    [Required]TimeOnly EndTime,
+    [Required][StringLength(10)] string Date,
+    [Required][StringLength(10)] string StartTime,
+    [Required][StringLength(10)] string EndTime,
     [Required] bool IsCompleted,
     int? PictogramId
 );

--- a/GirafAPI/Mapping/ActivityMapping.cs
+++ b/GirafAPI/Mapping/ActivityMapping.cs
@@ -10,9 +10,9 @@ public static class ActivityMapping
     {
         return new Activity
         {
-            Date = activityDto.Date,
-            StartTime = activityDto.StartTime,
-            EndTime = activityDto.EndTime,
+            Date = DateOnly.Parse(activityDto.Date),
+            StartTime = TimeOnly.Parse(activityDto.StartTime),
+            EndTime = TimeOnly.Parse(activityDto.EndTime),
             IsCompleted = false
         };
     }
@@ -21,9 +21,9 @@ public static class ActivityMapping
     {
         return new Activity
         {
-            Date = activityDto.Date,
-            StartTime = activityDto.StartTime,
-            EndTime = activityDto.EndTime,
+            Date = DateOnly.Parse(activityDto.Date),
+            StartTime = TimeOnly.Parse(activityDto.StartTime),
+            EndTime = TimeOnly.Parse(activityDto.EndTime),
             IsCompleted = false,
             Pictogram = pictogram
         };
@@ -34,9 +34,9 @@ public static class ActivityMapping
         return new Activity
         {
             Id = id,
-            Date = activityDto.Date,
-            StartTime = activityDto.StartTime,
-            EndTime = activityDto.EndTime,
+            Date = DateOnly.Parse(activityDto.Date),
+            StartTime = TimeOnly.Parse(activityDto.StartTime),
+            EndTime = TimeOnly.Parse(activityDto.EndTime),
             IsCompleted = activityDto.IsCompleted,
         };
     }
@@ -46,9 +46,9 @@ public static class ActivityMapping
         return new Activity
         {
             Id = id,
-            Date = activityDto.Date,
-            StartTime = activityDto.StartTime,
-            EndTime = activityDto.EndTime,
+            Date = DateOnly.Parse(activityDto.Date),
+            StartTime = TimeOnly.Parse(activityDto.StartTime),
+            EndTime = TimeOnly.Parse(activityDto.EndTime),
             IsCompleted = activityDto.IsCompleted,
             Pictogram = pictogram
         };


### PR DESCRIPTION
## Description
- Reverted (create/update)activityDTO date and time related fields back to strings
- Moved conversion to Date & Time back to mapping
- Updated relevant tests

## Related issues
Changes to expected DTO types breaking frontend activity requests

## Checklist
- [x] My code is in the right place.
- [x] My code fully addresses the issue I was working on.
- [x] I have added appropriate tests and error handling.
- [x] My code follows the style guidelines.
- [x] I have created a pull request and notified the teams.
