### PR TITLE
Changed some request to owner only

### DIFF
--- a/GirafAPI/Endpoints/OrganizationEndpoints.cs
+++ b/GirafAPI/Endpoints/OrganizationEndpoints.cs
@@ -304,7 +304,7 @@ public static class OrganizationEndpoints
             .WithName("AddOrganizationAdmin")
             .WithDescription("Adds an admin to an organization.")
             .WithTags("Organizations")
-            .RequireAuthorization("OrganizationAdmin")
+            .RequireAuthorization("OrganizationOwner")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
@@ -345,7 +345,7 @@ public static class OrganizationEndpoints
             .WithName("RemoveOrganizationAdmin")
             .WithDescription("Removes an admin from an organization.")
             .WithTags("Organizations")
-            .RequireAuthorization("OrganizationAdmin")
+            .RequireAuthorization("OrganizationOwner")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);

--- a/GirafAPI/Endpoints/OrganizationEndpoints.cs
+++ b/GirafAPI/Endpoints/OrganizationEndpoints.cs
@@ -231,11 +231,11 @@ public static class OrganizationEndpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status500InternalServerError);
 
-        group.MapGet("/grades/{orgId}", async (int orgId, GirafDbContext dbContext) =>
+        group.MapGet("/grades/{gradeId}", async (int gradeId, GirafDbContext dbContext) =>
             {
                 try
                 {
-                    Grade? grade = await dbContext.Grades.FindAsync(orgId);
+                    Grade? grade = await dbContext.Grades.FindAsync(gradeId);
                     if (grade is null)
                     {
                         return Results.NotFound();
@@ -265,7 +265,7 @@ public static class OrganizationEndpoints
             .WithName("GetOrganizationByGradeId")
             .WithDescription("Gets organization by grade id.")
             .WithTags("Organizations")
-            .RequireAuthorization("OrganizationMember")
+            .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);


### PR DESCRIPTION
## Description
Needed so only the organization owner can give and remove admin status
Also changes getOrgbyGradeID as it usex orgId instead of gradeId, because of this if i sent grade id 7, it checked org 7 for permissions instead of the actual org. This is also why i have just change the requireAuth to (), as i need this endpoint to fetch the orgId and can therefor not give it as a parameter.

## Checklist
- [X] My code is in the right place.\
- [X] My code fully addresses the issue I was working on.\
- [X] I have added appropriate tests and error handling.\
- [X] My code follows the style guidelines.\
- [] I have added relevant comments explaining the purpose and function of my code (if necessary).\
- [] I have added relevant documentation to the GitHub wiki.\
- [] I have created a pull request and notified the teams.
