### PR TITLE
Own data policy

### DIFF
--- a/Giraf.IntegrationTests/Endpoints/PictogramEndpointTests.cs
+++ b/Giraf.IntegrationTests/Endpoints/PictogramEndpointTests.cs
@@ -42,7 +42,7 @@ namespace Giraf.IntegrationTests.Endpoints
             formData.Add(new StringContent("TestPictogram"), "pictogramName");
 
             // Act
-            var response = await client.PostAsync("/pictograms/", formData);
+            var response = await client.PostAsync($"/pictograms/{organizationId}", formData);
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -75,16 +75,18 @@ namespace Giraf.IntegrationTests.Endpoints
             var formData = new MultipartFormDataContent();
             formData.Add(new StringContent("1"), "organizationId");
             formData.Add(new StringContent("TestPictogram"), "pictogramName");
+            
+            var organizatonId = seeder.Organizations[0].Id;
 
             // Act
-            var response = await client.PostAsync("/pictograms/", formData);
+            var response = await client.PostAsync($"/pictograms/{organizatonId}", formData);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [Fact]
-        public async Task CreatePictogram_ReturnsBadRequest_WhenOrganizationIdIsMissing()
+        public async Task CreatePictogram_ReturnsNotFound_WhenOrganizationIdIsInvalid()
         {
             // Arrange
             var factory = new GirafWebApplicationFactory();
@@ -105,12 +107,14 @@ namespace Giraf.IntegrationTests.Endpoints
 
             // Add pictogramName
             formData.Add(new StringContent("TestPictogram"), "pictogramName");
+            
+            var organizatonId = 999;
 
             // Act
-            var response = await client.PostAsync("/pictograms/", formData);
+            var response = await client.PostAsync($"/pictograms/{organizatonId}", formData);
 
             // Assert
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Fact]
@@ -139,7 +143,7 @@ namespace Giraf.IntegrationTests.Endpoints
             formData.Add(new StringContent(organizationId.ToString()), "organizationId");
 
             // Act
-            var response = await client.PostAsync("/pictograms/", formData);
+            var response = await client.PostAsync($"/pictograms/{organizationId}", formData);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -163,8 +167,10 @@ namespace Giraf.IntegrationTests.Endpoints
 
             int pictogramId = seeder.Pictograms[0].Id;
 
+            var organizationId = seeder.Organizations[0].Id;
+
             // Act
-            var response = await client.GetAsync($"/pictograms/{pictogramId}");
+            var response = await client.GetAsync($"/pictograms/{organizationId}/{pictogramId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -186,9 +192,11 @@ namespace Giraf.IntegrationTests.Endpoints
             client.AttachClaimsToken(scope, seeder.Users["member"]);
             
             int nonExistentPictogramId = 9999;
+            
+            var organizationId = seeder.Organizations[0].Id;
 
             // Act
-            var response = await client.GetAsync($"/pictograms/{nonExistentPictogramId}");
+            var response = await client.GetAsync($"/pictograms/{organizationId}/{nonExistentPictogramId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -216,7 +224,7 @@ namespace Giraf.IntegrationTests.Endpoints
             var pageSize = 10;
 
             // Act
-            var response = await client.GetAsync($"/pictograms/organizationId:int?organizationId={organizationId}&currentPage={currentPage}&pageSize={pageSize}");
+            var response = await client.GetAsync($"/pictograms/{organizationId}?currentPage={currentPage}&pageSize={pageSize}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -243,7 +251,7 @@ namespace Giraf.IntegrationTests.Endpoints
             var pageSize = 10;
 
             // Act
-            var response = await client.GetAsync($"/pictograms/organizationId:int?organizationId={organizationId}&currentPage={currentPage}&pageSize={pageSize}");
+            var response = await client.GetAsync($"/pictograms/{organizationId}?currentPage={currentPage}&pageSize={pageSize}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -268,10 +276,11 @@ namespace Giraf.IntegrationTests.Endpoints
 
             client.AttachClaimsToken(scope, seeder.Users["owner"]);
 
+            var organizationId = seeder.Organizations[0].Id;
             int pictogramId = seeder.Pictograms[0].Id;
 
             // Act
-            var response = await client.DeleteAsync($"/pictograms/{pictogramId}");
+            var response = await client.DeleteAsync($"/pictograms/{organizationId}/{pictogramId}");
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -297,10 +306,11 @@ namespace Giraf.IntegrationTests.Endpoints
 
             client.AttachClaimsToken(scope, seeder.Users["owner"]);
 
+            var organizationId = seeder.Organizations[0].Id;
             int nonExistentPictogramId = 9999;
 
             // Act
-            var response = await client.DeleteAsync($"/pictograms/{nonExistentPictogramId}");
+            var response = await client.DeleteAsync($"/pictograms/{organizationId}/{nonExistentPictogramId}");
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/Giraf.IntegrationTests/Endpoints/UsersEndpointTests.cs
+++ b/Giraf.IntegrationTests/Endpoints/UsersEndpointTests.cs
@@ -82,6 +82,8 @@ namespace Giraf.IntegrationTests.Endpoints
             seeder.SeedUsers(scope.ServiceProvider.GetRequiredService<UserManager<GirafUser>>());
             var client = factory.CreateClient();
 
+            client.AttachClaimsToken(scope, seeder.Users["member"]);
+
             var userId = seeder.Users["member"].Id;
 
             var updateUserDto = new UpdateUserDTO("UpdatedFirstName", "UpdatedLastName");
@@ -109,7 +111,12 @@ namespace Giraf.IntegrationTests.Endpoints
         {
             // Arrange
             var factory = new GirafWebApplicationFactory();
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            seeder.SeedUsers(scope.ServiceProvider.GetRequiredService<UserManager<GirafUser>>());
             var client = factory.CreateClient();
+
+            client.AttachClaimsToken(scope, seeder.Users["member"]);
 
             var updateUserDto = new UpdateUserDTO("NonExistentFirstName", "NonExistentLastName");
             var nonExistentUserId = "nonexistent_user_id";
@@ -125,43 +132,7 @@ namespace Giraf.IntegrationTests.Endpoints
 
         #region Get Users Tests
 
-        // 5. Test GET /users/ when there are users in the DB
-        [Fact]
-        public async Task GetUsers_ReturnsListOfUsers()
-        {
-            // Arrange
-            var factory = new GirafWebApplicationFactory();
-            var seeder = new EmptyDb();
-            var scope = factory.Services.CreateScope();
-            seeder.SeedUsers(scope.ServiceProvider.GetRequiredService<UserManager<GirafUser>>());
-            var client = factory.CreateClient();
-
-            // Act
-            var response = await client.GetAsync("/users");
-
-            // Assert
-            response.EnsureSuccessStatusCode();
-            var users = await response.Content.ReadFromJsonAsync<List<UserDTO>>();
-            Assert.NotNull(users);
-            Assert.NotEmpty(users);
-        }
-
-        // 6. Test GET /users when there are no users
-        [Fact]
-        public async Task GetUsers_ReturnsNotFound_WhenNoUsersExist()
-        {
-            // Arrange
-            var factory = new GirafWebApplicationFactory();
-            var client = factory.CreateClient();
-
-            // Act
-            var response = await client.GetAsync("/users");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        }
-
-        // 7. Test GET /users/{id} when the user exists
+        // 5. Test GET /users/{id} when the user exists
         [Fact]
         public async Task GetUserById_ReturnsUser_WhenUserExists()
         {
@@ -171,6 +142,8 @@ namespace Giraf.IntegrationTests.Endpoints
             var scope = factory.Services.CreateScope();
             seeder.SeedUsers(scope.ServiceProvider.GetRequiredService<UserManager<GirafUser>>());
             var client = factory.CreateClient();
+
+            client.AttachClaimsToken(scope, seeder.Users["member"]);
 
             var userId = seeder.Users["member"].Id;
 
@@ -184,13 +157,18 @@ namespace Giraf.IntegrationTests.Endpoints
             Assert.Equal(userId, user.Id);
         }
 
-        // 8. Test GET /users/{id} when the user does not exist
+        // 6. Test GET /users/{id} when the user does not exist
         [Fact]
         public async Task GetUserById_ReturnsNotFound_WhenUserDoesNotExist()
         {
             // Arrange
             var factory = new GirafWebApplicationFactory();
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            seeder.SeedUsers(scope.ServiceProvider.GetRequiredService<UserManager<GirafUser>>());
             var client = factory.CreateClient();
+
+            client.AttachClaimsToken(scope, seeder.Users["member"]);
 
             var nonExistentUserId = "nonexistent_user_id";
 
@@ -205,7 +183,7 @@ namespace Giraf.IntegrationTests.Endpoints
 
         #region Change Password Tests
 
-        // 9. Test PUT /users/{id}/change-password when the user and old password are valid
+        // 7. Test PUT /users/{id}/change-password when the user and old password are valid
         [Fact]
         public async Task ChangeUserPassword_ReturnsOk_WhenUserAndOldPasswordAreValid()
         {
@@ -234,7 +212,7 @@ namespace Giraf.IntegrationTests.Endpoints
         }
 
 
-        // 10. Test PUT /users/{id}/change-password when the user does not exist
+        // 8. Test PUT /users/{id}/change-password when the user does not exist
         [Fact]
         public async Task ChangeUserPassword_ReturnsBadRequest_WhenUserDoesNotExist()
         {
@@ -265,7 +243,7 @@ namespace Giraf.IntegrationTests.Endpoints
 
         #region Change Username Tests
 
-        // 11. Test PUT /users/{id}/change-username when the user and new username are valid
+        // 9. Test PUT /users/{id}/change-username when the user and new username are valid
         [Fact]
         public async Task ChangeUsername_ReturnsOk_WhenUserAndUsernameAreValid()
         {
@@ -296,7 +274,7 @@ namespace Giraf.IntegrationTests.Endpoints
             Assert.Equal("updatedUser", user.UserName);
         }
 
-        // 12. Test PUT /users/{id}/change-username when the user does not exist
+        // 10. Test PUT /users/{id}/change-username when the user does not exist
         [Fact]
         public async Task ChangeUsername_ReturnsBadRequest_WhenUserDoesNotExist()
         {
@@ -323,7 +301,7 @@ namespace Giraf.IntegrationTests.Endpoints
 
         #region Delete User Tests
 
-        // 13. Test DELETE /users/{id} when the user exists
+        // 11. Test DELETE /users/{id} when the user exists
         [Fact]
         public async Task DeleteUser_ReturnsNoContent_WhenUserExists()
         {
@@ -361,13 +339,18 @@ namespace Giraf.IntegrationTests.Endpoints
             Assert.Null(deletedUser);
         }
 
-        // 14. Test DELETE /users/{id} when the user does not exist
+        // 12. Test DELETE /users/{id} when the user does not exist
         [Fact]
         public async Task DeleteUser_ReturnsBadRequest_WhenUserDoesNotExist()
         {
             // Arrange
             var factory = new GirafWebApplicationFactory();
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            seeder.SeedUsers(scope.ServiceProvider.GetRequiredService<UserManager<GirafUser>>());
             var client = factory.CreateClient();
+
+            client.AttachClaimsToken(scope, seeder.Users["member"]);
 
             var nonExistentUserId = "nonexistent_user_id";
 

--- a/Giraf.IntegrationTests/Utils/GirafWebApplicationFactory.cs
+++ b/Giraf.IntegrationTests/Utils/GirafWebApplicationFactory.cs
@@ -51,6 +51,7 @@ internal class GirafWebApplicationFactory : WebApplicationFactory<Program>
             services.AddScoped<IAuthorizationHandler, OrgMemberAuthorizationHandler>();
             services.AddScoped<IAuthorizationHandler, OrgAdminAuthorizationHandler>();
             services.AddScoped<IAuthorizationHandler, OrgOwnerAuthorizationHandler>();
+            services.AddScoped<IAuthorizationHandler, OwnDataAuthorizationHandler>();
             
             services.AddAuthorization(options =>
             {
@@ -60,6 +61,8 @@ internal class GirafWebApplicationFactory : WebApplicationFactory<Program>
                     policy.Requirements.Add(new OrgAdminRequirement()));
                 options.AddPolicy("OrganizationOwner", policy =>
                     policy.Requirements.Add(new OrgOwnerRequirement()));
+                options.AddPolicy("OwnData", policy => 
+                    policy.Requirements.Add(new OwnDataRequirement()));
             });
 
             // Build the service provider and create a scope

--- a/GirafAPI/Authorization/OrgOwnerRequirement.cs
+++ b/GirafAPI/Authorization/OrgOwnerRequirement.cs
@@ -6,10 +6,7 @@ using Microsoft.AspNetCore.Identity;
 
 namespace GirafAPI.Authorization;
 
-public class OrgOwnerRequirement : IAuthorizationRequirement
-{
-    
-}
+public class OrgOwnerRequirement : IAuthorizationRequirement;
 
 public class OrgOwnerAuthorizationHandler : AuthorizationHandler<OrgOwnerRequirement>
 {

--- a/GirafAPI/Authorization/OwnDataRequirement.cs
+++ b/GirafAPI/Authorization/OwnDataRequirement.cs
@@ -1,0 +1,54 @@
+﻿using GirafAPI.Data;
+using GirafAPI.Entities.Users;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+
+namespace GirafAPI.Authorization;
+
+public class OwnDataRequirement : IAuthorizationRequirement;
+
+public class OwnDataAuthorizationHandler : AuthorizationHandler<OwnDataRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly UserManager<GirafUser> _userManager;
+    
+    public OwnDataAuthorizationHandler(
+        IHttpContextAccessor httpContextAccessor, 
+        UserManager<GirafUser> userManager)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _userManager = userManager;
+    }
+    
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        OwnDataRequirement requirement)
+    {
+        var userId = _userManager.GetUserId(_httpContextAccessor.HttpContext.User);
+        var user = await _userManager.FindByIdAsync(userId);
+
+        if (user == null)
+        {
+            context.Fail();
+            return;
+        }
+        
+        var httpContext = _httpContextAccessor.HttpContext;
+        var userIdInUrl = httpContext.Request.RouteValues["userId"].ToString();
+        
+        var targetUser = await _userManager.FindByIdAsync(userIdInUrl);
+        if (targetUser == null)
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        if (userId == userIdInUrl)
+        {
+            context.Succeed(requirement);
+            return;
+        }
+        
+        context.Fail();
+    }
+}

--- a/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -319,6 +319,7 @@ public static class ActivityEndpoints
             .WithName("CopyActivityForCitizen")
             .WithDescription("Copies activities between days for a citizen")
             .WithTags("Activities")
+            .RequireAuthorization()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status200OK)
             .RequireAuthorization();
@@ -382,6 +383,7 @@ public static class ActivityEndpoints
             .WithName("CopyActivityForGrade")
             .WithDescription("Copies activities between days for a grade")
             .WithTags("Activities")
+            .RequireAuthorization()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status200OK)
             .RequireAuthorization();
@@ -465,7 +467,13 @@ public static class ActivityEndpoints
                         statusCode: StatusCodes.Status500InternalServerError);
                 }
             })
-            .RequireAuthorization();
+            .WithName("CompleteActivity")
+            .WithDescription("Completes an existing activity using ID.")
+            .WithTags("Activities")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status500InternalServerError);
 
 
         // DELETE activity

--- a/GirafAPI/Extensions/ServiceExtensions.cs
+++ b/GirafAPI/Extensions/ServiceExtensions.cs
@@ -76,6 +76,7 @@ namespace GirafAPI.Extensions
             services.AddScoped<IAuthorizationHandler, OrgMemberAuthorizationHandler>();
             services.AddScoped<IAuthorizationHandler, OrgAdminAuthorizationHandler>();
             services.AddScoped<IAuthorizationHandler, OrgOwnerAuthorizationHandler>();
+            services.AddScoped<IAuthorizationHandler, OwnDataAuthorizationHandler>();
             
             services.AddAuthorization(options =>
             {
@@ -85,6 +86,8 @@ namespace GirafAPI.Extensions
                     policy.Requirements.Add(new OrgAdminRequirement()));
                 options.AddPolicy("OrganizationOwner", policy =>
                     policy.Requirements.Add(new OrgOwnerRequirement()));
+                options.AddPolicy("OwnData", policy => 
+                    policy.Requirements.Add(new OwnDataRequirement()));
             });
 
             return services;

--- a/README.md
+++ b/README.md
@@ -1,37 +1,41 @@
 # weekplanner-api
- The backend API for the GIRAF weekplaner app
+This is the backend REST API for the weekplanner branch of the GIRAF project.
+The weekplanner API uses Microsoft's .NET 8 architecture with a modern MinimalAPI
+setup. It also includes a containerized PostgreSql database.
 
 ## Get Started
-1. Install Microsoft Entity Framework
+1. Download and install .NET 8 from:
+   
+   https://dotnet.microsoft.com/en-us/download/dotnet
+
+2. Install Microsoft Entity Framework:
     ```bash
     dotnet tool install --global dotnet-ef
     ```
-2. Run the API from the GirafAPI directory
+3. Download and install Docker Desktop from:
+   
+   https://www.docker.com/products/docker-desktop/
+
+4. Launch the API from the weekplanner-api directory:
     ```bash
-    dotnet run
+    docker compose up
     ```
+
+## Production Environment
+The production environment uses a different build process from 
+the development environment. To run the production environment, call:
+```bash
+docker compose -f docker-compose.prod.yml up --build
+```
 
 ## Update the Database
 If you make changes to entities or DTOs, make sure to update the database:
 
 1. Add a new migration
-   ```bash
-   dotnet ef migrations add {NewMigrationName} --output-dir Data\Migrations
+   ```
+   dotnet ef migrations add Your_Migration_Name_Here --output-dir Data\Migrations
    ```
 2. Update the database
    ```bash
    dotnet ef database update
    ```
-   
-## Running in a Container
-
-### Development Environment
-```
-docker compose up
-```
-(If you are running the api on Linux and it does not seem to be working, try changing the port in docker-compose.yml to 5171:8080 instead of 5171:5171)
-
-### Production Environment
-```
-docker compose -f docker-compose.prod.yml up --build
-```


### PR DESCRIPTION
## Description
This PR contains authorization for User endpoints, with a new policy to check if the user is accessing their own data, and authorization for pictogram endpoints. Note that a few endpoints (including all pictogram endpoints) have had the organization id added to the route values, so some endpoint routes will need to be changed on the frontend.

## Checklist
- [x] My code is in the right place.\
- [x] My code fully addresses the issue I was working on.\
- [x] I have added appropriate tests and error handling.\
- [x] My code follows the style guidelines.\
- [x] I have added relevant comments explaining the purpose and function of my code (if necessary).\
- [x] I have added relevant documentation to the GitHub wiki.\
- [x] I have created a pull request and notified the teams.
